### PR TITLE
Add demo notebooks from explainability repo

### DIFF
--- a/notebooks/Watson OpenScale Explanation for Image Binary Classification Model.ipynb
+++ b/notebooks/Watson OpenScale Explanation for Image Binary Classification Model.ipynb
@@ -1,0 +1,638 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<img src=\"https://github.com/pmservice/ai-openscale-tutorials/raw/master/notebooks/images/banner.png\" align=\"left\" alt=\"banner\">"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Tutorial on generating an explanation for an image-based binary classifier model on Watson OpenScale"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Contents:\n",
+    "- [1. Setup](#setup)\n",
+    "- [2. Creating and deploying an image-based model](#deployment)\n",
+    "- [3. Subscriptions](#subscription)\n",
+    "- [4. Explainability](#explainability)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id=\"setup\"></a>\n",
+    "## 1. Setup\n",
+    "\n",
+    "### 1.1 Install AIOS and WML packages"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install --upgrade ibm-ai-openscale --no-cache | tail -n 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install --upgrade watson-machine-learning-client --no-cache | tail -n 1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note: Restart the kernel to assure the new libraries are being used."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1.2 Configure credentials"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Get AIOS (AI Openscale) `apikey` by going to the [Bluemix console](https://console.bluemix.net/) and clicking `Manage->Account->Users`. Select `Platform API Keys` from the sidebar and then click the \"Create\" button.\n",
+    "\n",
+    "One can obtain the AIOS `instance_id` (guid) by accessing the [cloud console](https://console.bluemix.net/services) and clicking anywhere on the AIOS service tile except for the service link and then checking the popping sidebar on the right."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "AIOS_CREDENTIALS = {\n",
+    "    \"instance_guid\": \"*****\",\n",
+    "    \"apikey\": \"*****\", \n",
+    "    \"url\": \"https://api.aiopenscale.cloud.ibm.com\"\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Generate or fetch the WML credentials by clicking on `Credentials` in the sidebar of the provisioned WML page and paste it below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "WML_CREDENTIALS = {\n",
+    "    \"apikey\": \"*****\",\n",
+    "    \"iam_apikey_description\": \"*****\",\n",
+    "    \"iam_apikey_name\": \"*****\",\n",
+    "    \"iam_role_crn\": \"crn:v1:bluemix:public:iam::::serviceRole:Writer\",\n",
+    "    \"iam_serviceid_crn\": \"*****\",\n",
+    "    \"instance_id\": \"*****\",\n",
+    "    \"password\": \"*****\",\n",
+    "    \"url\": \"https://us-south.ml.cloud.ibm.com\",\n",
+    "    \"username\": \"*****\"\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id=\"deployment\"></a>\n",
+    "## 2. Creating and deploying an image-based model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We are going to create a binary classifier which classifies an image as a Dog or a Cat (Probability: 1 = dog, 0 = cat). The dataset can be downloaded from here: https://www.kaggle.com/c/dogs-vs-cats-redux-kernels-edition/data. The dataset can also be found here: https://ibm.box.com/shared/static/itl0el289mz06py2e6aemehx6lge1rou.zip\n",
+    "\n",
+    "Now, create a folder named `data` and inside it create subdirectories: `train` and `validation`. Further, create folders named `dogs` and `cats` (as shown below) with 1024 dog and cat images in the `train` directory and 416 dog and cat images in the `validation` directory respectively. Post unzipping the downloaded zip file, use the images from the `train` folder found after unzipping `train.zip`.\n",
+    "\n",
+    "```python\n",
+    "data/\n",
+    "    train/\n",
+    "        dogs/ # 1024 pictures\n",
+    "            dog.1.jpg\n",
+    "            dog.2.jpg\n",
+    "            ...\n",
+    "        cats/ # 1024 pictures\n",
+    "            cat.1.jpg\n",
+    "            cat.2.jpg\n",
+    "            ...\n",
+    "    validation/\n",
+    "        dogs/ # 416 pictures\n",
+    "            dog.1025.jpg\n",
+    "            dog.1026.jpg\n",
+    "            ...\n",
+    "        cats/ # 416 pictures\n",
+    "            cat.1025.jpg\n",
+    "            cat.1026.jpg\n",
+    "            ...\n",
+    "```\n",
+    "\n",
+    "Note: Tensorflow versions supported by WML are: 1.2, 1.5, and 1.11. Make sure you have one of these versions before creating the models. Version 1.11 is used in this notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install keras\n",
+    "!pip install tensorflow==1.11.0\n",
+    "!pip install keras_sequential_ascii\n",
+    "!pip install numpy\n",
+    "!pip install pillow\n",
+    "\n",
+    "import keras\n",
+    "from keras.models import Sequential\n",
+    "from keras.layers import Activation, Dropout, Flatten, Dense\n",
+    "from keras.layers import Convolution2D, MaxPooling2D, ZeroPadding2D\n",
+    "from keras.preprocessing.image import ImageDataGenerator\n",
+    "from keras_sequential_ascii import sequential_model_to_ascii_printout\n",
+    "from keras import backend as keras_backend\n",
+    "from keras import optimizers\n",
+    "from keras import applications\n",
+    "from keras.models import Model\n",
+    "import numpy as np\n",
+    "print(keras.__version__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2.1 Creating a model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Dimension of the images\n",
+    "img_width, img_height = 90, 90\n",
+    "\n",
+    "train_data_dir = 'dogs-cats/data/train'\n",
+    "validation_data_dir = 'dogs-cats/data/validation'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note: Please modify the paths above accordingly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Preprocessing\n",
+    "\n",
+    "#used to rescale the pixel values from [0, 255] to [0, 1] interval\n",
+    "datagen = ImageDataGenerator(rescale=1./255)\n",
+    "batch_size = 32\n",
+    "\n",
+    "# automagically retrieve images and their classes for train and validation sets\n",
+    "train_generator = datagen.flow_from_directory(\n",
+    "        train_data_dir,\n",
+    "        target_size=(img_width, img_height),\n",
+    "        batch_size=batch_size,\n",
+    "        class_mode='binary')\n",
+    "\n",
+    "validation_generator = datagen.flow_from_directory(\n",
+    "        validation_data_dir,\n",
+    "        target_size=(img_width, img_height),\n",
+    "        batch_size=batch_size,\n",
+    "        class_mode='binary')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define Model\n",
+    "\n",
+    "def base_model():\n",
+    "    model = Sequential()\n",
+    "    model.add(Convolution2D(32, (3, 3), input_shape=(img_width, img_height, 3)))\n",
+    "    model.add(Activation('relu'))\n",
+    "    model.add(MaxPooling2D(pool_size=(2, 2)))\n",
+    "\n",
+    "    model.add(Convolution2D(32, (3, 3)))\n",
+    "    model.add(Activation('relu'))\n",
+    "    model.add(MaxPooling2D(pool_size=(2, 2)))\n",
+    "\n",
+    "    model.add(Convolution2D(64, (3, 3)))\n",
+    "    model.add(Activation('relu'))\n",
+    "    model.add(MaxPooling2D(pool_size=(2, 2)))\n",
+    "\n",
+    "    model.add(Dropout(0.5))\n",
+    "    model.add(Flatten())\n",
+    "    model.add(Dense(64, activation='relu'))\n",
+    "    model.add(Dropout(0.5))\n",
+    "    model.add(Dense(1, activation='sigmoid'))\n",
+    "\n",
+    "    model.compile(loss='binary_crossentropy',\n",
+    "              optimizer='rmsprop',\n",
+    "              metrics=['accuracy'])\n",
+    "    \n",
+    "    return model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "epochs = 10 # One can increase the no. of epochs to get better accuracy\n",
+    "train_samples = 2048\n",
+    "validation_samples = 832"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cnn_n = base_model()\n",
+    "cnn_n.summary()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Vizualizing model structure\n",
+    "sequential_model_to_ascii_printout(cnn_n)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Train the model\n",
+    "cnn_n.fit_generator(\n",
+    "    train_generator,\n",
+    "    steps_per_epoch=train_samples // batch_size,\n",
+    "    epochs=epochs,\n",
+    "    validation_steps=validation_samples // batch_size,\n",
+    "    validation_data=validation_generator\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cnn_n.save('dog_cat_cnn.h5')\n",
+    "!rm dog_cat_cnn.tar*\n",
+    "!tar -czvf dog_cat_cnn.tar.gz dog_cat_cnn.h5\n",
+    "!rm dog_cat_cnn.h5"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scores = cnn_n.evaluate_generator(validation_generator, validation_samples)\n",
+    "print(scores)\n",
+    "print(\"Accuracy: %.2f%%\" % (scores[1]*100))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2.2 Storing the model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from watson_machine_learning_client import WatsonMachineLearningAPIClient\n",
+    "\n",
+    "wml_client = WatsonMachineLearningAPIClient(WML_CREDENTIALS)\n",
+    "\n",
+    "model_name = \"Dog-Cat binary\"\n",
+    "\n",
+    "# Update the FRAMEWORK_VERSION below depending on the tensorflow version used\n",
+    "model_meta = {\n",
+    "    wml_client.repository.ModelMetaNames.NAME: model_name,\n",
+    "    wml_client.repository.ModelMetaNames.DESCRIPTION: \"Dog-Cat binary\",\n",
+    "    wml_client.repository.ModelMetaNames.FRAMEWORK_NAME: \"tensorflow\",\n",
+    "    wml_client.repository.ModelMetaNames.FRAMEWORK_VERSION: \"1.11\",\n",
+    "    wml_client.repository.ModelMetaNames.FRAMEWORK_LIBRARIES: [\n",
+    "         {\"name\": \"keras\", \"version\": \"2.2.4\"}\n",
+    "    ]\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "published_model_details = wml_client.repository.store_model(model='dog_cat_cnn.tar.gz', meta_props=model_meta)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_uid = wml_client.repository.get_model_uid(published_model_details)\n",
+    "print(model_uid)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2.3 Deploying the model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "deployment= wml_client.deployments.create(name= model_name + \" Deployment\", model_uid=model_uid)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scoring_url = wml_client.deployments.get_scoring_url(deployment)\n",
+    "print(scoring_url)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install matplotlib\n",
+    "!pip install opencv-python \n",
+    "\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import cv2\n",
+    "\n",
+    "%matplotlib inline \n",
+    "img = cv2.imread(\"dogs-vs-cats/data/train/dogs/dog.4.jpg\")\n",
+    "img = cv2.resize(img, (90, 90))\n",
+    "print(img.shape)\n",
+    "plt.imshow(img, cmap='gray')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Subscriptions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 3.1 Configuring AIOS"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ibm_ai_openscale import APIClient\n",
+    "from ibm_ai_openscale.engines import WatsonMachineLearningAsset\n",
+    "\n",
+    "aios_client = APIClient(AIOS_CREDENTIALS)\n",
+    "aios_client.version"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 3.2 Subscribe the asset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ibm_ai_openscale.supporting_classes import *\n",
+    "\n",
+    "subscription = aios_client.data_mart.subscriptions.add(WatsonMachineLearningAsset(\n",
+    "    model_uid,\n",
+    "    problem_type=ProblemType.BINARY_CLASSIFICATION,\n",
+    "    input_data_type=InputDataType.UNSTRUCTURED_IMAGE,\n",
+    "    probability_column='probability'\n",
+    "))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 3.3 Score the model and get transaction-id"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scoring_data = {'values': [img.tolist()]}\n",
+    "predictions = wml_client.deployments.score(scoring_url, scoring_data)\n",
+    "print(predictions)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "transaction_id = subscription.payload_logging.get_table_content().scoring_id[0]\n",
+    "print(transaction_id)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id=\"explainability\"></a>\n",
+    "## 4. Explainability"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4.1 Configure Explainability"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "subscription.explainability.enable()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "subscription.explainability.get_details()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4.2 Get explanation for the transaction"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "explanation = subscription.explainability.run(transaction_id, background_mode=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "explanation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### The explanation images can be obtained using the cells below"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install Pillow\n",
+    "from PIL import Image\n",
+    "import base64\n",
+    "import io\n",
+    "\n",
+    "pred = explanation[\"entity\"][\"predictions\"][0]\n",
+    "print(\"Explanation for {} region:\".format(pred[\"value\"]))\n",
+    "\n",
+    "img = pred[\"explanation_features\"][0][\"full_image\"]\n",
+    "img_data = base64.b64decode(img)\n",
+    "Image.open(io.BytesIO(img_data))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pred = explanation[\"entity\"][\"predictions\"][1]\n",
+    "print(\"Explanation for {} region:\".format(pred[\"value\"]))\n",
+    "\n",
+    "img = pred[\"explanation_features\"][0][\"full_image\"]\n",
+    "img_data = base64.b64decode(img)\n",
+    "Image.open(io.BytesIO(img_data))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebooks/Watson OpenScale Explanation for Image Multiclass Classification Model.ipynb
+++ b/notebooks/Watson OpenScale Explanation for Image Multiclass Classification Model.ipynb
@@ -1,0 +1,619 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<img src=\"https://github.com/pmservice/ai-openscale-tutorials/raw/master/notebooks/images/banner.png\" align=\"left\" alt=\"banner\">"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Tutorial on generating an explanation for an image-based model on Watson OpenScale"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook includes steps for creating an image-based watson-machine-learning model, creating a subscription, configuring explainability, and finally generating an explanation for a transaction."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Contents\n",
+    "- [1. Setup](#setup)\n",
+    "- [2. Creating and deploying an image-based model](#deployment)\n",
+    "- [3. Subscriptions](#subscription)\n",
+    "- [4. Explainability](#explainability)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Note**: If using Watson Studio, try running the notebook on atleast 'Default Python 3.5 XS' version for faster results."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id=\"setup\"></a>\n",
+    "## 1. Setup\n",
+    "\n",
+    "### 1.1 Install Watson OpenScale and WML packages"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install --upgrade ibm-ai-openscale --no-cache | tail -n 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install --upgrade watson-machine-learning-client --no-cache | tail -n 1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note: Restart the kernel to assure the new libraries are being used."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1.2 Configure credentials"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Get the Watson Openscale `apikey` by going to the [Bluemix console](https://console.bluemix.net/) and clicking `Manage->Account->Users`. Select `Platform API Keys` from the sidebar and then click the \"Create\" button.\n",
+    "\n",
+    "One can obtain the Watson OpenScale `instance_id` (guid) by accessing the [cloud console](https://cloud.ibm.com/resources), clicking on `Services` and clicking anywhere on the Watson OpenScale service tile except for the service link and then checking the popping sidebar on the right."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "AIOS_CREDENTIALS = {\n",
+    "    \"instance_guid\": \"*****\",\n",
+    "    \"apikey\": \"*****\", \n",
+    "    \"url\": \"https://api.aiopenscale.cloud.ibm.com\"\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Generate or fetch the WML credentials by clicking on `Credentials` in the sidebar of the provisioned WML page and paste it below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "WML_CREDENTIALS = {\n",
+    "    \"apikey\": \"*****\",\n",
+    "    \"iam_apikey_description\": \"*****\",\n",
+    "    \"iam_apikey_name\": \"*****\",\n",
+    "    \"iam_role_crn\": \"crn:v1:bluemix:public:iam::::serviceRole:Writer\",\n",
+    "    \"iam_serviceid_crn\": \"*****\",\n",
+    "    \"instance_id\": \"*****\",\n",
+    "    \"password\": \"*****\",\n",
+    "    \"url\": \"https://us-south.ml.cloud.ibm.com\",\n",
+    "    \"username\": \"*****\"\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id=\"deployment\"></a>\n",
+    "## 2. Creating and deploying an image-based model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The dataset used is MNIST dataset of handwritten digits. It consists of 60,000 28x28 grayscale images of the 10 digits, along with a test set of 10,000 images. More information about the dataset can be found here: https://keras.io/datasets/#mnist-database-of-handwritten-digits\n",
+    "\n",
+    "Note: Tensorflow versions supported by WML are: 1.2, 1.5, and 1.11. Make sure you have one of these versions before creating the models. Version 1.11 is used in this notebook."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2.1 Creating a model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install keras\n",
+    "!pip install tensorflow==1.11.0\n",
+    "!pip install keras_sequential_ascii\n",
+    "\n",
+    "import keras\n",
+    "from keras.datasets import mnist\n",
+    "from keras.models import Sequential\n",
+    "from keras.layers import Dense, Dropout, Flatten\n",
+    "from keras.layers import Conv2D, MaxPooling2D\n",
+    "from keras_sequential_ascii import sequential_model_to_ascii_printout\n",
+    "from keras import backend as keras_backend\n",
+    "print(keras.__version__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "batch_size = 128\n",
+    "num_classes = 10\n",
+    "epochs = 5"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# input image dimensions\n",
+    "img_rows, img_cols = 28, 28\n",
+    "\n",
+    "# the data, split between train and test sets\n",
+    "(x_train, y_train), (x_test, y_test) = mnist.load_data()\n",
+    "\n",
+    "if keras_backend.image_data_format() == 'channels_first':\n",
+    "    x_train = x_train.reshape(x_train.shape[0], 1, img_rows, img_cols)\n",
+    "    x_test = x_test.reshape(x_test.shape[0], 1, img_rows, img_cols)\n",
+    "    input_shape = (1, img_rows, img_cols)\n",
+    "else:\n",
+    "    x_train = x_train.reshape(x_train.shape[0], img_rows, img_cols, 1)\n",
+    "    x_test = x_test.reshape(x_test.shape[0], img_rows, img_cols, 1)\n",
+    "    input_shape = (img_rows, img_cols, 1)\n",
+    "\n",
+    "x_train = x_train.astype('float32')\n",
+    "x_test = x_test.astype('float32')\n",
+    "x_train /= 255\n",
+    "x_test /= 255\n",
+    "\n",
+    "print('x_train shape:', x_train.shape)\n",
+    "print(x_train.shape[0], 'train samples')\n",
+    "print(x_test.shape[0], 'test samples')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# convert class vectors to binary class matrices\n",
+    "y_train = keras.utils.to_categorical(y_train, num_classes)\n",
+    "y_test = keras.utils.to_categorical(y_test, num_classes)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define Model\n",
+    "\n",
+    "def base_model():\n",
+    "    model = Sequential()\n",
+    "    model.add(Conv2D(32, kernel_size=(3, 3), activation='relu', input_shape=input_shape))\n",
+    "    model.add(Conv2D(64, (3, 3), activation='relu'))\n",
+    "    model.add(MaxPooling2D(pool_size=(2, 2)))\n",
+    "    model.add(Dropout(0.25))\n",
+    "    model.add(Flatten())\n",
+    "    model.add(Dense(128, activation='relu'))\n",
+    "    model.add(Dropout(0.5))\n",
+    "    model.add(Dense(num_classes, activation='softmax'))\n",
+    "\n",
+    "    model.compile(loss=keras.losses.categorical_crossentropy,\n",
+    "                  optimizer=keras.optimizers.Adadelta(),\n",
+    "                  metrics=['accuracy'])\n",
+    "    return model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cnn_n = base_model()\n",
+    "cnn_n.summary()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Vizualizing model structure\n",
+    "sequential_model_to_ascii_printout(cnn_n)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Fit model\n",
+    "print(y_train.shape)\n",
+    "cnn = cnn_n.fit(x_train, y_train, batch_size=batch_size, epochs=epochs, validation_data=(x_test, y_test))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scores = cnn_n.evaluate(x_test, y_test, verbose=0)\n",
+    "print(scores)\n",
+    "print(\"Accuracy: %.2f%%\" % (scores[1]*100))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2.2 Storing the model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from watson_machine_learning_client import WatsonMachineLearningAPIClient\n",
+    "\n",
+    "wml_client = WatsonMachineLearningAPIClient(WML_CREDENTIALS)\n",
+    "cnn_n.save(\"mnist_cnn.h5\")\n",
+    "!rm mnist_cnn.tar*\n",
+    "!tar -czvf mnist_cnn.tar.gz mnist_cnn.h5"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!rm mnist_cnn.h5"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_name = \"MNIST Model\"\n",
+    "\n",
+    "# Update the FRAMEWORK_VERSION below depending on the tensorflow version used\n",
+    "model_meta = {\n",
+    "    wml_client.repository.ModelMetaNames.NAME: model_name,\n",
+    "    wml_client.repository.ModelMetaNames.DESCRIPTION: \"MNIST model\",\n",
+    "    wml_client.repository.ModelMetaNames.FRAMEWORK_NAME: \"tensorflow\",\n",
+    "    wml_client.repository.ModelMetaNames.FRAMEWORK_VERSION: \"1.11\",\n",
+    "    wml_client.repository.ModelMetaNames.FRAMEWORK_LIBRARIES: [\n",
+    "         {\"name\": \"keras\", \"version\": \"2.2.4\"}\n",
+    "    ]\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "published_model_details = wml_client.repository.store_model(model='mnist_cnn.tar.gz', meta_props=model_meta)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_uid = wml_client.repository.get_model_uid(published_model_details)\n",
+    "model_uid"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2.3 Deploying the model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "deployment= wml_client.deployments.create(name= model_name + \" Deployment\", model_uid=model_uid)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scoring_url = wml_client.deployments.get_scoring_url(deployment)\n",
+    "print(scoring_url)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Subscriptions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 3.1 Configuring OpenScale"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ibm_ai_openscale import APIClient\n",
+    "from ibm_ai_openscale.engines import WatsonMachineLearningAsset\n",
+    "\n",
+    "aios_client = APIClient(AIOS_CREDENTIALS)\n",
+    "aios_client.version"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 3.2 Subscribe the asset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ibm_ai_openscale.supporting_classes import *\n",
+    "\n",
+    "subscription = aios_client.data_mart.subscriptions.add(WatsonMachineLearningAsset(\n",
+    "    model_uid,\n",
+    "    problem_type=ProblemType.MULTICLASS_CLASSIFICATION,\n",
+    "    input_data_type=InputDataType.UNSTRUCTURED_IMAGE,\n",
+    "    probability_column='probability'\n",
+    "))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aios_client.data_mart.subscriptions.list()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "subscription.get_details()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 3.3 Score the model and get transaction-id"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install numpy\n",
+    "!pip install matplotlib\n",
+    "\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "%matplotlib inline \n",
+    "img = np.array(x_test[999], dtype='float')\n",
+    "pixels = img.reshape((28, 28))\n",
+    "plt.imshow(pixels, cmap='gray')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scoring_data = {'values': [x_test[999].tolist()]}\n",
+    "predictions = wml_client.deployments.score(scoring_url, scoring_data)\n",
+    "print(predictions)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "transaction_id = subscription.payload_logging.get_table_content().scoring_id[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id=\"explainability\"></a>\n",
+    "## 4. Explainability"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4.1 Configure Explainability"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "subscription.explainability.enable()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "subscription.explainability.get_details()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4.2 Get explanation for the transaction"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "explanation = subscription.explainability.run(transaction_id, background_mode=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "explanation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### The explanation images can be obtained using the cells below"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install Pillow\n",
+    "from PIL import Image\n",
+    "import base64\n",
+    "import io\n",
+    "\n",
+    "img = explanation[\"entity\"][\"predictions\"][0][\"explanation_features\"][0][\"full_image\"]\n",
+    "img_data = base64.b64decode(img)\n",
+    "Image.open(io.BytesIO(img_data))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "img = explanation[\"entity\"][\"predictions\"][1][\"explanation_features\"][0][\"full_image\"]\n",
+    "img_data = base64.b64decode(img)\n",
+    "Image.open(io.BytesIO(img_data))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebooks/Watson OpenScale Explanation for Tabular Model.ipynb
+++ b/notebooks/Watson OpenScale Explanation for Tabular Model.ipynb
@@ -1,0 +1,639 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<img src=\"https://github.com/pmservice/ai-openscale-tutorials/raw/master/notebooks/images/banner.png\" align=\"left\" alt=\"banner\">"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Tutorial on generating an explanation for a tabular model on Watson OpenScale"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook includes steps for creating a tabular watson-machine-learning model, creating a subscription, configuring explainability, and finally generating an explanation for a transaction."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Contents\n",
+    "- [1. Setup](#setup)\n",
+    "- [2. Creating and deploying a tabular model](#deployment)\n",
+    "- [3. Subscriptions](#subscription)\n",
+    "- [4. Explainability](#explainability)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Note**: If using Watson Studio, try running the notebook on atleast 'Default Python 3.5 XS' version for faster results."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id=\"setup\"></a>\n",
+    "## 1. Setup\n",
+    "\n",
+    "### 1.1 Install Watson OpenScale and WML packages"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install --upgrade ibm-ai-openscale --no-cache | tail -n 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install --upgrade watson-machine-learning-client --no-cache | tail -n 1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note: Restart the kernel to assure the new libraries are being used."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1.2 Configure credentials"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Get the Watson Openscale `apikey` by going to the [Bluemix console](https://console.bluemix.net/) and clicking `Manage->Account->Users`. Select `Platform API Keys` from the sidebar and then click the \"Create\" button.\n",
+    "\n",
+    "One can obtain the Watson OpenScale `instance_id` (guid) by accessing the [cloud console](https://cloud.ibm.com/resources), clicking on `Services` and clicking anywhere on the Watson OpenScale service tile except for the service link and then checking the popping sidebar on the right."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "AIOS_CREDENTIALS = {\n",
+    "    \"instance_guid\": \"*****\",\n",
+    "    \"apikey\": \"*****\", \n",
+    "    \"url\": \"https://api.aiopenscale.cloud.ibm.com\"\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Generate or fetch the WML credentials by clicking on `Credentials` in the sidebar of the provisioned WML page. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "WML_CREDENTIALS = {\n",
+    "    \"apikey\": \"*****\",\n",
+    "    \"iam_apikey_description\": \"*****\",\n",
+    "    \"iam_apikey_name\": \"*****\",\n",
+    "    \"iam_role_crn\": \"crn:v1:bluemix:public:iam::::serviceRole:Writer\",\n",
+    "    \"iam_serviceid_crn\": \"*****\",\n",
+    "    \"instance_id\": \"*****\",\n",
+    "    \"password\": \"*****\",\n",
+    "    \"url\": \"https://us-south.ml.cloud.ibm.com\",\n",
+    "    \"username\": \"*****\"\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Generate COS credentials by going to the provisioned COS service page and selecting `Writer` role. Specify the following in the \"Add Inline Configuration Parameters (Optional)\" field: `{\"HMAC\":true}`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cos_credentials = {\n",
+    "    \"apikey\": \"*****\",\n",
+    "    \"cos_hmac_keys\": {\n",
+    "        \"access_key_id\": \"*****\",\n",
+    "        \"secret_access_key\": \"*****\"\n",
+    "    },\n",
+    "    \"endpoints\": \"https://control.cloud-object-storage.cloud.ibm.com/v2/endpoints\",\n",
+    "    \"iam_apikey_description\": \"*****\",\n",
+    "    \"iam_apikey_name\": \"*****\",\n",
+    "    \"iam_role_crn\": \"crn:v1:bluemix:public:iam::::serviceRole:Writer\",\n",
+    "    \"iam_serviceid_crn\": \"*****\",\n",
+    "    \"resource_instance_id\": \"*****\"\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id=\"deployment\"></a>\n",
+    "## 2. Creating and deploying a tabular model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The dataset used is \"GoSales Transactions for Naive Bayes Model\" which is publicly available (on Data Science Experience Community). The file would be downloaded in the next step.\n",
+    "      \n",
+    "The dataset details anonymous outdoor equipment purchases to be used for multiclass classification. It is used to create a model below to predict the product line that the customer must be most interested in, such as golf accessories, camping equipment, and others."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2.1 Load the training data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!rm GoSales_Tx.csv\n",
+    "!wget https://raw.githubusercontent.com/pmservice/wml-sample-models/master/spark/product-line-prediction/data/GoSales_Tx.csv"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2.2 Uploading the dataset to COS "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "!pip install ibm-cos-sdk\n",
+    "\n",
+    "from ibm_botocore.client import Config\n",
+    "import ibm_boto3\n",
+    "  \n",
+    "cos_url = \"*****\" # example: https://s3-api.us-geo.objectstorage.softlayer.net\n",
+    "auth_endpoint = \"*****\" # example: https://iam.bluemix.net/oidc/token\n",
+    "bucket = \"*****\"\n",
+    "\n",
+    "cos = ibm_boto3.resource(service_name=\"s3\",\n",
+    "        ibm_api_key_id=cos_credentials[\"apikey\"],\n",
+    "        ibm_auth_endpoint=auth_endpoint,\n",
+    "        config=Config(signature_version='oauth'),\n",
+    "        endpoint_url=cos_url)\n",
+    "\n",
+    "# Delete the file if it already exists in COS\n",
+    "cos.Object(bucket, 'GoSales_Tx.csv').delete()\n",
+    "\n",
+    "# Upload the file to COS\n",
+    "cos.Object(bucket, 'GoSales_Tx.csv').upload_file('GoSales_Tx.csv')\n",
+    "print(\"\\nUpload Complete\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2.3 Creating a model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Note**: Skip the pyspark install step below if you are using a Spark kernel on Watson Studio."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install pyspark==2.3.1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Note**: When running this notebook locally, If the `SparkSession` import fails below, set 'SPARK_HOME' environment variable with the path to `pyspark` installation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pyspark.sql import SparkSession\n",
+    "\n",
+    "spark = SparkSession.builder.getOrCreate()\n",
+    "df = spark.read.csv(path=\"GoSales_Tx.csv\", sep=\",\", header=True, inferSchema=True)\n",
+    "df.show(5, truncate = False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_df, test_df = df.randomSplit([0.8, 0.2], seed=12345)\n",
+    "print(\"Total count of data set: {}\".format(df.count()))\n",
+    "print(\"Total count of training data set: {}\".format(train_df.count()))\n",
+    "print(\"Total count of test data set: {}\".format(test_df.count()))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pyspark.ml.feature import OneHotEncoder, StringIndexer, IndexToString, VectorAssembler\n",
+    "from pyspark.ml.classification import RandomForestClassifier\n",
+    "from pyspark.ml.evaluation import MulticlassClassificationEvaluator\n",
+    "from pyspark.ml import Pipeline, Model\n",
+    "\n",
+    "stringIndexer_label = StringIndexer(inputCol=\"PRODUCT_LINE\", outputCol=\"label\").fit(df)\n",
+    "stringIndexer_prof = StringIndexer(inputCol=\"PROFESSION\", outputCol=\"PROFESSION_index\")\n",
+    "stringIndexer_gend = StringIndexer(inputCol=\"GENDER\", outputCol=\"GENDER_index\")\n",
+    "stringIndexer_mar = StringIndexer(inputCol=\"MARITAL_STATUS\", outputCol=\"MARITAL_STATUS_index\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vectorAssembler_features = VectorAssembler(inputCols=[\"GENDER_index\", \"AGE\", \"MARITAL_STATUS_index\", \"PROFESSION_index\"], outputCol=\"features\")\n",
+    "rf = RandomForestClassifier(labelCol=\"label\", featuresCol=\"features\")\n",
+    "labelConverter = IndexToString(inputCol=\"prediction\", outputCol=\"predictedLabel\", labels=stringIndexer_label.labels)\n",
+    "pipeline = Pipeline(stages=[stringIndexer_label, stringIndexer_prof, stringIndexer_gend, stringIndexer_mar, vectorAssembler_features, rf, labelConverter])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_rf = pipeline.fit(train_df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "predictions = model_rf.transform(test_df)\n",
+    "evaluator = MulticlassClassificationEvaluator(labelCol=\"label\", predictionCol=\"prediction\", metricName=\"accuracy\")\n",
+    "accuracy = evaluator.evaluate(predictions)\n",
+    "\n",
+    "print(\"Accuracy = %g\" % accuracy)\n",
+    "print(\"Test Error = %g\" % (1.0 - accuracy))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "training_data_reference = {\n",
+    "    \"name\": \"GoSales data reference\",\n",
+    "    \"connection\": {\n",
+    "      \"iam_url\": auth_endpoint,\n",
+    "      \"api_key\": cos_credentials[\"apikey\"],\n",
+    "      \"url\": cos_url,\n",
+    "      \"resource_instance_id\": cos_credentials[\"resource_instance_id\"]\n",
+    "    },\n",
+    "    \"source\": {\n",
+    "      \"firstlineheader\": \"true\",\n",
+    "      \"file_format\": \"csv\",\n",
+    "      \"file_name\": \"GoSales_Tx.csv\",\n",
+    "      \"bucket\": bucket,\n",
+    "      \"type\": \"bluemixcloudobjectstorage\"\n",
+    "    }\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from watson_machine_learning_client import WatsonMachineLearningAPIClient\n",
+    "\n",
+    "wml_client = WatsonMachineLearningAPIClient(WML_CREDENTIALS)\n",
+    "MODEL_NAME = \"Go-Sales multiclass model\"\n",
+    "\n",
+    "model_props = {\n",
+    "    wml_client.repository.ModelMetaNames.NAME: \"{}\".format(MODEL_NAME),\n",
+    "    wml_client.repository.ModelMetaNames.TRAINING_DATA_REFERENCE: training_data_reference\n",
+    "}\n",
+    "\n",
+    "# publish model \n",
+    "published_model_details = wml_client.repository.store_model(model=model_rf, meta_props=model_props, training_data=train_df, pipeline=pipeline)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_uid = wml_client.repository.get_model_uid(published_model_details)\n",
+    "print(model_uid)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2.4 Deploying the model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "deployment = wml_client.deployments.create(model_uid, MODEL_NAME + \" deployment\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scoring_url = wml_client.deployments.get_scoring_url(deployment)\n",
+    "print(scoring_url)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get a response from the deployed model for an input row\n",
+    "\n",
+    "fields = [\"GENDER\", \"AGE\", \"MARITAL_STATUS\", \"PROFESSION\"]\n",
+    "values = [[\"M\", 26, \"Single\", \"Other\"]]\n",
+    "\n",
+    "payload = {\"fields\": fields, \"values\": values}\n",
+    "response = wml_client.deployments.score(scoring_url=scoring_url, payload=payload)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(response)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id=\"subscription\"></a>\n",
+    "## 3. Subscriptions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 3.1 Configuring OpenScale"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ibm_ai_openscale import APIClient\n",
+    "from ibm_ai_openscale.engines import WatsonMachineLearningAsset\n",
+    "\n",
+    "aios_client = APIClient(AIOS_CREDENTIALS)\n",
+    "aios_client.version"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Note**: Please re-run the above cell if it doesn't work the first time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aios_client.data_mart.bindings.list()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 3.2 Subscribe the asset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ibm_ai_openscale.supporting_classes import *\n",
+    "\n",
+    "subscription = aios_client.data_mart.subscriptions.add(WatsonMachineLearningAsset(\n",
+    "    model_uid,\n",
+    "    problem_type=ProblemType.MULTICLASS_CLASSIFICATION,\n",
+    "    input_data_type=InputDataType.STRUCTURED,\n",
+    "    label_column='PRODUCT_LINE',\n",
+    "    feature_columns = [\"GENDER\", \"AGE\", \"MARITAL_STATUS\", \"PROFESSION\"],\n",
+    "    categorical_columns = [\"GENDER\", \"MARITAL_STATUS\", \"PROFESSION\"],\n",
+    "    prediction_column='predictedLabel',\n",
+    "    probability_column='probability'\n",
+    "))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 3.3 Get subscription"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aios_client.data_mart.subscriptions.list()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "subscription.get_details()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 3.4 Score the model and get transaction-id"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fields = [\"GENDER\", \"AGE\", \"MARITAL_STATUS\", \"PROFESSION\"]\n",
+    "values = [[\"M\", 26, \"Single\", \"Other\"]]\n",
+    "\n",
+    "payload = {\"fields\": fields, \"values\": values}\n",
+    "response = wml_client.deployments.score(scoring_url=scoring_url, payload=payload)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Note**: Please wait for a few seconds before running the cell below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "transaction_id = subscription.payload_logging.get_table_content().scoring_id[0]\n",
+    "print(transaction_id)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id=\"explainability\"></a>\n",
+    "## 4. Explainability"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4.1 Configure Explainability"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "subscription.explainability.enable()\n",
+    "subscription.explainability.get_details()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4.2 Get explanation for the transaction"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "subscription.explainability.run(transaction_id, background_mode=False)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebooks/Watson OpenScale Explanation for Text Model.ipynb
+++ b/notebooks/Watson OpenScale Explanation for Text Model.ipynb
@@ -1,0 +1,533 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<img src=\"https://github.com/pmservice/ai-openscale-tutorials/raw/master/notebooks/images/banner.png\" align=\"left\" alt=\"banner\">"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Tutorial on generating an explanation for a text-based model on Watson OpenScale"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook includes steps for creating a text-based watson-machine-learning model, creating a subscription, configuring explainability, and finally generating an explanation for a transaction."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Contents\n",
+    "- [1. Setup](#setup)\n",
+    "- [2. Creating and deploying a text-based model](#)\n",
+    "- [3. Subscriptions](#subscription)\n",
+    "- [4. Explainability](#explainability)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Note**: If using Watson Studio, try running the notebook on atleast 'Default Python 3.5 XS' version for faster results."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id=\"setup\"></a>\n",
+    "## 1. Setup\n",
+    "\n",
+    "### 1.1 Install Watson OpenScale and WML packages"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install --upgrade ibm-ai-openscale --no-cache | tail -n 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install --upgrade watson-machine-learning-client --no-cache | tail -n 1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note: Restart the kernel to assure the new libraries are being used."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1.2 Configure credentials"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Get the Watson Openscale `apikey` by going to the [Bluemix console](https://console.bluemix.net/) and clicking `Manage->Account->Users`. Select `Platform API Keys` from the sidebar and then click the \"Create\" button.\n",
+    "\n",
+    "One can obtain the Watson OpenScale `instance_id` (guid) by accessing the [cloud console](https://cloud.ibm.com/resources), clicking on `Services` and clicking anywhere on the Watson OpenScale service tile except for the service link and then checking the popping sidebar on the right."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "AIOS_CREDENTIALS = {\n",
+    "    \"instance_guid\": \"*****\",\n",
+    "    \"apikey\": \"*****\", \n",
+    "    \"url\": \"https://api.aiopenscale.cloud.ibm.com\"\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Generate or fetch the WML credentials by clicking on `Credentials` in the sidebar of the provisioned WML page. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "WML_CREDENTIALS = {\n",
+    "    \"apikey\": \"*****\",\n",
+    "    \"instance_id\": \"*****\",\n",
+    "    \"url\": \"https://us-south.ml.cloud.ibm.com\"\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Creating and deploying a text-based model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The dataset used is the UCI-ML SMS Spam Collection Dataset which can be found here: https://archive.ics.uci.edu/ml/machine-learning-databases/00228/. It is a binary classification dataset with the labels being 'ham' and 'spam'."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2.1 Loading the training data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The training data is downloaded and saved as 'SMSSpam.csv' in this step\n",
+    "\n",
+    "!pip install pandas\n",
+    "!rm smsspamcollection.zip\n",
+    "!wget https://archive.ics.uci.edu/ml/machine-learning-databases/00228/smsspamcollection.zip\n",
+    "!unzip smsspamcollection.zip\n",
+    "\n",
+    "import pandas as pd\n",
+    "\n",
+    "pd.read_csv(\"SMSSpamCollection\",sep=\"\\t\",header=None, encoding=\"utf-8\").to_csv(\"SMSSpam.csv\", header=[\"label\", \"text\"], sep=\",\", index=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!rm SMSSpamCollection\n",
+    "!rm readme\n",
+    "!rm smsspamcollection.zip"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2.2 Creating a model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Note**: Skip the pyspark install step below if you are using a Spark kernel on Watson Studio."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install pyspark==2.3.1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Note**: When running this notebook locally, If the `SparkSession` import fails below, set 'SPARK_HOME' environment variable with the path to `pyspark` installation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pyspark.sql import SparkSession\n",
+    "\n",
+    "spark = SparkSession.builder.getOrCreate()\n",
+    "df = spark.read.csv(path=\"SMSSpam.csv\", header=True, multiLine=True, escape='\"')\n",
+    "df.show(5, truncate = False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_df, test_df = df.randomSplit([0.8, 0.2], seed=12345)\n",
+    "print(\"Total count of data set: {}\".format(df.count()))\n",
+    "print(\"Total count of training data set: {}\".format(train_df.count()))\n",
+    "print(\"Total count of test data set: {}\".format(test_df.count()))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install nltk\n",
+    "from pyspark.ml.feature import StringIndexer, IndexToString, CountVectorizer, Tokenizer, IDF, StopWordsRemover\n",
+    "from pyspark.ml.classification import GBTClassifier\n",
+    "from pyspark.ml.evaluation import BinaryClassificationEvaluator\n",
+    "from pyspark.ml import Pipeline, Model\n",
+    "import nltk\n",
+    "from nltk.tokenize import word_tokenize\n",
+    "from nltk.corpus import stopwords\n",
+    "\n",
+    "nltk.download('punkt')\n",
+    "nltk.download('stopwords')\n",
+    "stop_words = list(set(stopwords.words('english')))\n",
+    "\n",
+    "stringIndexer_label = StringIndexer(inputCol=\"label\", outputCol=\"label_ix\").fit(df)\n",
+    "tokenizer = Tokenizer(inputCol=\"text\", outputCol=\"words\")\n",
+    "stopword_remover = StopWordsRemover(inputCol=\"words\", outputCol=\"filtered_words\").setStopWords(stop_words)\n",
+    "count = CountVectorizer(inputCol=\"filtered_words\", outputCol=\"rawFeatures\")\n",
+    "idf = IDF(inputCol=\"rawFeatures\", outputCol=\"features\")\n",
+    "nb = GBTClassifier(labelCol=\"label_ix\")\n",
+    "labelConverter = IndexToString(inputCol=\"prediction\", outputCol=\"predictionLabel\", labels=stringIndexer_label.labels)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pipeline = Pipeline(stages=[stringIndexer_label, tokenizer, stopword_remover, count, idf, nb, labelConverter])\n",
+    "model = pipeline.fit(train_df)\n",
+    "predictions = model.transform(test_df)\n",
+    "evaluator = BinaryClassificationEvaluator(labelCol=\"label_ix\", rawPredictionCol=\"prediction\", metricName=\"areaUnderROC\")\n",
+    "auc = evaluator.evaluate(predictions)\n",
+    "\n",
+    "print(\"Area under ROC curve = %g\" % auc)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from watson_machine_learning_client import WatsonMachineLearningAPIClient\n",
+    "\n",
+    "MODEL_NAME = \"Text Binary Classifier\"\n",
+    "wml_client = WatsonMachineLearningAPIClient(WML_CREDENTIALS)\n",
+    "\n",
+    "model_props = {\n",
+    "    wml_client.repository.ModelMetaNames.NAME: \"{}\".format(MODEL_NAME),\n",
+    "}\n",
+    "\n",
+    "# publish model \n",
+    "published_model_details = wml_client.repository.store_model(model=model, meta_props=model_props, training_data=train_df, pipeline=pipeline)\n",
+    "\n",
+    "!rm SMSSpam.csv"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_uid = wml_client.repository.get_model_uid(published_model_details)\n",
+    "print(model_uid)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2.3 Deploying the model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "deployment = wml_client.deployments.create(model_uid, MODEL_NAME + \" deployment\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scoring_url = wml_client.deployments.get_scoring_url(deployment)\n",
+    "print(scoring_url)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Subscriptions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 3.1 Configuring AIOS"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ibm_ai_openscale import APIClient\n",
+    "from ibm_ai_openscale.engines import WatsonMachineLearningAsset\n",
+    "\n",
+    "aios_client = APIClient(AIOS_CREDENTIALS)\n",
+    "aios_client.version"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Note**: Please re-run the above cell if it doesn't work the first time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aios_client.data_mart.bindings.list()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 3.2 Subscribe the asset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ibm_ai_openscale.supporting_classes import *\n",
+    "\n",
+    "subscription = aios_client.data_mart.subscriptions.add(WatsonMachineLearningAsset(\n",
+    "    model_uid,\n",
+    "    label_column='label',\n",
+    "    problem_type=ProblemType.BINARY_CLASSIFICATION,\n",
+    "    input_data_type=InputDataType.UNSTRUCTURED_TEXT,\n",
+    "    feature_columns = [\"text\"],\n",
+    "    categorical_columns = [\"text\"],\n",
+    "    prediction_column='predictionLabel',\n",
+    "    probability_column='probability'\n",
+    "))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 3.3 Get subscription"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aios_client.data_mart.subscriptions.list()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "subscription.get_details()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 3.4 Score the model and get transaction-id"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "text = \"SIX chances to win CASH! From 100 to 20,000 pounds txt> CSH11 and send to 87575. Cost 150p/day, 6days, 16+ TsandCs apply Reply HL 4 info\"\n",
+    "payload = {\"fields\": [\"text\"], \"values\": [[text]]}\n",
+    "\n",
+    "response = wml_client.deployments.score(scoring_url=scoring_url, payload=payload)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(response)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Note**: Please wait for a few seconds before running the cell below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "transaction_id = subscription.payload_logging.get_table_content().scoring_id[0]\n",
+    "print(transaction_id)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Explainability"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4.1 Configure Explainability"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "subscription.explainability.enable()\n",
+    "subscription.explainability.get_details()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4.2 Get explanation for the transaction"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "subscription.explainability.run(transaction_id, background_mode=False)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.6",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
@msochka mentioned that as the explainability demo notebooks linked in the OpenScale docs are available in the private explainability repository hence they are not publicly accessible. Raising this PR so that they can be publicly linked in the OpenScale documentation.